### PR TITLE
Cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
-##  Enigma Self-Assessment
+#  Enigma Self-Assessment
 
-# Functionality (3)
+## Functionality (3)
 
   - Enigma Class with encrypt and decrypt methods implemented and functional
 
   - Encrypt/decrypt command line interfaces implemented and functional
 
-# Object Oriented Programming (3)
+## Object Oriented Programming (3)
 
   - Project includes a module, albeit very basic, that can be used outside the project
 
@@ -20,7 +20,7 @@
 
   - All that being said, there's definitely a self-diagnosed case of class-phobia going on here
 
-# Test Driven Development(4)
+## Test Driven Development(4)
 
   - SimpleCov shows 100% test coverage
 
@@ -28,7 +28,7 @@
 
   - All test names clearly communicate the purpose of the test
 
-# Version Control(4)
+## Version Control(4)
 
   - 20+ pull requests with detailed comments
 

--- a/lib/enigma.rb
+++ b/lib/enigma.rb
@@ -40,7 +40,8 @@ class Enigma
   end
 
   def encrypt(message, key = default_key, date = default_date)
-    @key = key; @date = date
+    @key  = key
+    @date = date
     encode_all_characters(message)
     encryption_hash
   end
@@ -62,7 +63,9 @@ class Enigma
   end
 
   def decrypt(message, key, date = default_date)
-    @key = key; @date = date; @message = message
+    @key     = key
+    @date    = date
+    @message = message
     decode_all_characters(message)
     decryption_hash
   end

--- a/lib/enigma.rb
+++ b/lib/enigma.rb
@@ -1,9 +1,3 @@
-require './lib/shift_calculator'
-require './lib/caesar_cipher'
-require './lib/offsettable'
-require './lib/keyable'
-require './lib/datable'
-
 class Enigma
   include Offsettable, Keyable, Datable
 


### PR DESCRIPTION
Change markdown formatting in README, move assignments in encrypt/decrypt methods onto multiple lines, rather than being separated by a semi-colon, remove unnecessary file requires from Enigma.